### PR TITLE
Use validate_json.yml with relative paths

### DIFF
--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Validate JSON
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
-          INPUT_SCHEMA: /schema_tools/validator/test_schema.json
-          INPUT_JSONS: /schema_tools/validator/test_invalid_schema.json,/schema_tools/validator/test_valid_schema.json
+          INPUT_SCHEMA: ./schema_tools/validator/test_schema.json
+          INPUT_JSONS: ./schema_tools/validator/test_invalid_schema.json,./schema_tools/validator/test_valid_schema.json


### PR DESCRIPTION
This workflow seems to validate correctly. The only difference from master is the use of `./` relative paths. The clue for me was the readme of the validate-json-action.