### PR TITLE
Fix JSON validation and schema errors

### DIFF
--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -32,9 +32,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
+      - run: npm install -g ajv-cli
       - name: Validate JSON
         run: |
-          npm install -g ajv-cli
-          pwd
-          ls
-          ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json
+          cd schema
+          ajv -s main.json -r '*.json' -d ../conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d ../conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -29,3 +29,12 @@ jobs:
           cd schema
           make
           echo {} > test.json
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10'
+      - name: Validate JSON
+        run: |
+          npm install ajv-cli
+          pwd
+          ls
+          /usr/local/bin/ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -29,23 +29,6 @@ jobs:
           cd schema
           make
           echo {} > test.json
-###      - name: Run import tools on test data
-###        run: |
-###          # TODO: use requirements file
-###          pip install pyyaml pandas humanfriendly tqdm exifread pillow
-###
-###          cd conversion_tools/cwfid_to_json/
-###          curl -L https://github.com/cwfid/dataset/archive/36290d0.tar.gz | tar xzv
-###          mv dataset-36290d0*/* .
-###          python cwfid_to_json.py
-###
-###          cd ../deepweeds_to_json
-###          curl -L https://github.com/AlexOlsen/DeepWeeds/archive/51e3fab.tar.gz | tar xzv
-###          mv DeepWeeds-51e3fab*/* .
-###          # fake some images: make them all be a pic from cwfid
-###          mkdir deepweeds_images_full
-###          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/images/001_image.png deepweeds_images_full/$fname; done
-###          python deepweeds_to_json.py --labels-dir labels --image-dir deepweeds_images_full -o deepweeds_imageinfo.json
       - name: Validate JSON
         uses: docker://3scale/ajv:latest
         run: |

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -35,7 +35,8 @@ jobs:
           cd conversion_tools/cwfid_to_json/
           curl -L https://github.com/cwfid/dataset/archive/36290d0.tar.gz | tar xzv
           mv dataset-36290d0*/* .
-          python cwfid_to_json.py
+          mv images cwfid_images
+          python cwfid_to_json.py --image-dir cwfid_images
           cd ../deepweeds_to_json
           curl -L https://github.com/AlexOlsen/DeepWeeds/archive/51e3fab.tar.gz | tar xzv
           mv DeepWeeds-51e3fab*/* .

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -28,7 +28,6 @@ jobs:
           pip install pyyaml
           cd schema
           make
-          echo {} > test.json
       - uses: actions/setup-node@v1
         with:
           node-version: '10'

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -29,12 +29,3 @@ jobs:
           cd schema
           make
           echo {} > test.json
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '10'
-        run: npm install ajv-cli
-      - name: Validate JSON
-        run: |
-          pwd
-          ls
-          /usr/local/bin/ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '10'
       - name: Validate JSON
         run: |
-          npm install ajv-cli
+          npm install -g ajv-cli
           pwd
           ls
-          /usr/local/bin/ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json
+          ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -29,25 +29,26 @@ jobs:
           cd schema
           make
           echo {} > test.json
-      - name: Run import tools on test data
-        run: |
-          # TODO: use requirements file
-          pip install pyyaml pandas humanfriendly tqdm exifread pillow
-
-          cd conversion_tools/cwfid_to_json/
-          curl -L https://github.com/cwfid/dataset/archive/36290d0.tar.gz | tar xzv
-          mv dataset-36290d0*/* .
-          python cwfid_to_json.py
-
-          cd ../deepweeds_to_json
-          curl -L https://github.com/AlexOlsen/DeepWeeds/archive/51e3fab.tar.gz | tar xzv
-          mv DeepWeeds-51e3fab*/* .
-          # fake some images: make them all be a pic from cwfid
-          mkdir deepweeds_images_full
-          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/images/001_image.png deepweeds_images_full/$fname; done
-          python deepweeds_to_json.py --labels-dir labels --image-dir deepweeds_images_full -o deepweeds_imageinfo.json
+###      - name: Run import tools on test data
+###        run: |
+###          # TODO: use requirements file
+###          pip install pyyaml pandas humanfriendly tqdm exifread pillow
+###
+###          cd conversion_tools/cwfid_to_json/
+###          curl -L https://github.com/cwfid/dataset/archive/36290d0.tar.gz | tar xzv
+###          mv dataset-36290d0*/* .
+###          python cwfid_to_json.py
+###
+###          cd ../deepweeds_to_json
+###          curl -L https://github.com/AlexOlsen/DeepWeeds/archive/51e3fab.tar.gz | tar xzv
+###          mv DeepWeeds-51e3fab*/* .
+###          # fake some images: make them all be a pic from cwfid
+###          mkdir deepweeds_images_full
+###          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/images/001_image.png deepweeds_images_full/$fname; done
+###          python deepweeds_to_json.py --labels-dir labels --image-dir deepweeds_images_full -o deepweeds_imageinfo.json
       - name: Validate JSON
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: ./schema/main.json
-          INPUT_JSONS: ./conversion_tools/cwfid_to_json/cwfid_imageinfo.json,./conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json
+        uses: docker://3scale/ajv:latest
+        run: |
+          pwd
+          ls
+          /usr/local/bin/ajv -s main.json -r '*.json' -d conversion_tools/cwfid_to_json/cwfid_imageinfo.json -d conversion_tools/deepweeds_to_json/deepweeds_imageinfo.json

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -29,8 +29,11 @@ jobs:
           cd schema
           make
           echo {} > test.json
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10'
+        run: npm install ajv-cli
       - name: Validate JSON
-        uses: docker://3scale/ajv:latest
         run: |
           pwd
           ls

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -28,6 +28,21 @@ jobs:
           pip install pyyaml
           cd schema
           make
+      - name: Run import tools on test data
+        run: |
+          # TODO: use requirements file
+          pip install pyyaml pandas humanfriendly tqdm exifread pillow
+          cd conversion_tools/cwfid_to_json/
+          curl -L https://github.com/cwfid/dataset/archive/36290d0.tar.gz | tar xzv
+          mv dataset-36290d0*/* .
+          python cwfid_to_json.py
+          cd ../deepweeds_to_json
+          curl -L https://github.com/AlexOlsen/DeepWeeds/archive/51e3fab.tar.gz | tar xzv
+          mv DeepWeeds-51e3fab*/* .
+          # fake some images: make them all be a pic from cwfid
+          mkdir deepweeds_images_full
+          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/images/001_image.png deepweeds_images_full/$fname; done
+          python deepweeds_to_json.py --labels-dir labels --image-dir deepweeds_images_full -o deepweeds_imageinfo.json
       - uses: actions/setup-node@v1
         with:
           node-version: '10'

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -42,7 +42,7 @@ jobs:
           mv DeepWeeds-51e3fab*/* .
           # fake some images: make them all be a pic from cwfid
           mkdir deepweeds_images_full
-          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/images/001_image.png deepweeds_images_full/$fname; done
+          for fname in $(cut -d, -f1 < labels.csv); do ln -s ../../cwfid_to_json/cwfid_images/001_image.png deepweeds_images_full/$fname; done
           python deepweeds_to_json.py --labels-dir labels --image-dir deepweeds_images_full -o deepweeds_imageinfo.json
       - uses: actions/setup-node@v1
         with:

--- a/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
+++ b/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
@@ -17316,7 +17316,7 @@
             "location_lat": 53,
             "location_long": 11,
             "location_datum": 4326,
-            "upload_time": "2020-09-02 23:07:48",
+            "upload_time": "2020-09-02 23:21:11",
             "camera_make": "JAI AD-130GE",
             "camera_lens": "Fujinon TF15-DA-8",
             "camera_lens_focallength": 15,
@@ -17336,7 +17336,7 @@
             "year": 2015,
             "identifier": "doi:10.1007/978-3-319-16220-1_8",
             "rights": "All data is subject to copyright and may only be used for non-commercial research. In case of use please cite our publication.",
-            "accrual_policy": "Closed",
+            "accrual_policy": "closed",
             "id": 0
         }
     ],

--- a/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
+++ b/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
@@ -17316,7 +17316,7 @@
             "location_lat": 53,
             "location_long": 11,
             "location_datum": 4326,
-            "upload_time": "2020-09-02 23:03:57",
+            "upload_time": "2020-09-02 23:07:48",
             "camera_make": "JAI AD-130GE",
             "camera_lens": "Fujinon TF15-DA-8",
             "camera_lens_focallength": 15,

--- a/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
+++ b/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
@@ -4,7 +4,7 @@
             "id": 46,
             "file_name": "cwfid_images/046_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -13,7 +13,7 @@
             "id": 1,
             "file_name": "cwfid_images/001_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -22,7 +22,7 @@
             "id": 18,
             "file_name": "cwfid_images/018_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -31,7 +31,7 @@
             "id": 25,
             "file_name": "cwfid_images/025_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -40,7 +40,7 @@
             "id": 17,
             "file_name": "cwfid_images/017_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -49,7 +49,7 @@
             "id": 50,
             "file_name": "cwfid_images/050_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -58,7 +58,7 @@
             "id": 49,
             "file_name": "cwfid_images/049_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -67,7 +67,7 @@
             "id": 33,
             "file_name": "cwfid_images/033_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -76,7 +76,7 @@
             "id": 9,
             "file_name": "cwfid_images/009_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -85,7 +85,7 @@
             "id": 34,
             "file_name": "cwfid_images/034_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -94,7 +94,7 @@
             "id": 57,
             "file_name": "cwfid_images/057_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -103,7 +103,7 @@
             "id": 10,
             "file_name": "cwfid_images/010_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -112,7 +112,7 @@
             "id": 58,
             "file_name": "cwfid_images/058_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -121,7 +121,7 @@
             "id": 22,
             "file_name": "cwfid_images/022_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -130,7 +130,7 @@
             "id": 6,
             "file_name": "cwfid_images/006_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -139,7 +139,7 @@
             "id": 41,
             "file_name": "cwfid_images/041_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -148,7 +148,7 @@
             "id": 8,
             "file_name": "cwfid_images/008_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -157,7 +157,7 @@
             "id": 35,
             "file_name": "cwfid_images/035_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -166,7 +166,7 @@
             "id": 11,
             "file_name": "cwfid_images/011_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -175,7 +175,7 @@
             "id": 56,
             "file_name": "cwfid_images/056_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -184,7 +184,7 @@
             "id": 23,
             "file_name": "cwfid_images/023_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -193,7 +193,7 @@
             "id": 59,
             "file_name": "cwfid_images/059_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -202,7 +202,7 @@
             "id": 40,
             "file_name": "cwfid_images/040_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -211,7 +211,7 @@
             "id": 7,
             "file_name": "cwfid_images/007_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -220,7 +220,7 @@
             "id": 47,
             "file_name": "cwfid_images/047_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -229,7 +229,7 @@
             "id": 19,
             "file_name": "cwfid_images/019_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -238,7 +238,7 @@
             "id": 24,
             "file_name": "cwfid_images/024_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -247,7 +247,7 @@
             "id": 51,
             "file_name": "cwfid_images/051_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -256,7 +256,7 @@
             "id": 16,
             "file_name": "cwfid_images/016_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -265,7 +265,7 @@
             "id": 32,
             "file_name": "cwfid_images/032_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -274,7 +274,7 @@
             "id": 48,
             "file_name": "cwfid_images/048_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -283,7 +283,7 @@
             "id": 13,
             "file_name": "cwfid_images/013_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -292,7 +292,7 @@
             "id": 54,
             "file_name": "cwfid_images/054_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -301,7 +301,7 @@
             "id": 37,
             "file_name": "cwfid_images/037_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -310,7 +310,7 @@
             "id": 42,
             "file_name": "cwfid_images/042_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -319,7 +319,7 @@
             "id": 5,
             "file_name": "cwfid_images/005_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -328,7 +328,7 @@
             "id": 38,
             "file_name": "cwfid_images/038_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -337,7 +337,7 @@
             "id": 21,
             "file_name": "cwfid_images/021_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -346,7 +346,7 @@
             "id": 26,
             "file_name": "cwfid_images/026_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -355,7 +355,7 @@
             "id": 2,
             "file_name": "cwfid_images/002_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -364,7 +364,7 @@
             "id": 45,
             "file_name": "cwfid_images/045_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -373,7 +373,7 @@
             "id": 30,
             "file_name": "cwfid_images/030_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -382,7 +382,7 @@
             "id": 53,
             "file_name": "cwfid_images/053_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -391,7 +391,7 @@
             "id": 14,
             "file_name": "cwfid_images/014_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -400,7 +400,7 @@
             "id": 29,
             "file_name": "cwfid_images/029_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -409,7 +409,7 @@
             "id": 27,
             "file_name": "cwfid_images/027_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -418,7 +418,7 @@
             "id": 60,
             "file_name": "cwfid_images/060_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -427,7 +427,7 @@
             "id": 44,
             "file_name": "cwfid_images/044_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -436,7 +436,7 @@
             "id": 3,
             "file_name": "cwfid_images/003_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -445,7 +445,7 @@
             "id": 31,
             "file_name": "cwfid_images/031_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -454,7 +454,7 @@
             "id": 15,
             "file_name": "cwfid_images/015_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -463,7 +463,7 @@
             "id": 28,
             "file_name": "cwfid_images/028_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -472,7 +472,7 @@
             "id": 52,
             "file_name": "cwfid_images/052_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -481,7 +481,7 @@
             "id": 55,
             "file_name": "cwfid_images/055_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -490,7 +490,7 @@
             "id": 12,
             "file_name": "cwfid_images/012_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -499,7 +499,7 @@
             "id": 36,
             "file_name": "cwfid_images/036_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -508,7 +508,7 @@
             "id": 4,
             "file_name": "cwfid_images/004_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -517,7 +517,7 @@
             "id": 39,
             "file_name": "cwfid_images/039_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -526,7 +526,7 @@
             "id": 43,
             "file_name": "cwfid_images/043_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -535,7 +535,7 @@
             "id": 20,
             "file_name": "cwfid_images/020_image.png",
             "license": 0,
-            "agdata_id": 0,
+            "agcontext_id": 0,
             "width": 1296,
             "height": 966,
             "resolution": 1251936
@@ -17303,7 +17303,7 @@
     ],
     "agcontexts": [
         {
-            "agcontext_id": 0,
+            "id": 0,
             "agcontext_name": "cwfid",
             "crop_type": "horticulture",
             "bbch_descriptive_text": "leaf development",
@@ -17316,7 +17316,7 @@
             "location_lat": 53,
             "location_long": 11,
             "location_datum": 4326,
-            "upload_time": "2020-08-28 09:31:22",
+            "upload_time": "2020-09-02 22:56:08",
             "camera_make": "JAI AD-130GE",
             "camera_lens": "Fujinon TF15-DA-8",
             "camera_lens_focallength": 15,

--- a/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
+++ b/conversion_tools/cwfid_to_json/cwfid_imageinfo.json
@@ -17305,7 +17305,7 @@
         {
             "id": 0,
             "agcontext_name": "cwfid",
-            "crop_type": "horticulture",
+            "crop_type": "other",
             "bbch_descriptive_text": "leaf development",
             "bbch_code": "GS10-19",
             "grains_descriptive_text": "seedling",
@@ -17316,7 +17316,7 @@
             "location_lat": 53,
             "location_long": 11,
             "location_datum": 4326,
-            "upload_time": "2020-09-02 22:56:08",
+            "upload_time": "2020-09-02 23:03:57",
             "camera_make": "JAI AD-130GE",
             "camera_lens": "Fujinon TF15-DA-8",
             "camera_lens_focallength": 15,

--- a/conversion_tools/cwfid_to_json/cwfid_to_json.py
+++ b/conversion_tools/cwfid_to_json/cwfid_to_json.py
@@ -7,6 +7,7 @@ Ingests CWFID .yaml annotations and images to produce a WeedCOCO .JSON file.
 
 """Constants and environment"""
 
+import warnings
 import argparse
 import yaml
 import pathlib
@@ -79,6 +80,7 @@ def get_image_dimensions(path):
     Function to measure image dimensions and calculate resolution.
     """
     if not os.path.isfile(path):
+        warnings.warn(f"Could not open {path}")
         return None
     # Retrieve image width and height
     image = PIL.Image.open(path)
@@ -101,7 +103,7 @@ Datasets can be concatenated to include images from multiple different agcontext
 """
 agcontext = [
     {
-        "agcontext_id": 0,
+        "id": 0,
         "agcontext_name": "cwfid",
         "crop_type": "horticulture",
         "bbch_descriptive_text": "leaf development",
@@ -159,7 +161,7 @@ for ann_path in progress:
         "id": image_id,
         "file_name": os.path.join(args.image_dir, ann_blob["filename"]),
         "license": 0,  # TODO
-        "agdata_id": 0,
+        "agcontext_id": 0,
     }
     dims = get_image_dimensions(args.image_dir / ann_blob["filename"])
 

--- a/conversion_tools/cwfid_to_json/cwfid_to_json.py
+++ b/conversion_tools/cwfid_to_json/cwfid_to_json.py
@@ -105,7 +105,7 @@ agcontext = [
     {
         "id": 0,
         "agcontext_name": "cwfid",
-        "crop_type": "horticulture",
+        "crop_type": "other",
         "bbch_descriptive_text": "leaf development",
         "bbch_code": "GS10-19",
         "grains_descriptive_text": "seedling",

--- a/conversion_tools/cwfid_to_json/cwfid_to_json.py
+++ b/conversion_tools/cwfid_to_json/cwfid_to_json.py
@@ -184,7 +184,7 @@ for ann_path in progress:
             "year": 2015,
             "identifier": "doi:10.1007/978-3-319-16220-1_8",
             "rights": "All data is subject to copyright and may only be used for non-commercial research. In case of use please cite our publication.",
-            "accrual_policy": "Closed",
+            "accrual_policy": "closed",
             "id": 0,
         }
     ]

--- a/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
+++ b/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
@@ -152,7 +152,6 @@ for iRow, row in tqdm(input_metadata.iterrows(), total=len(input_metadata)):
     ann["id"] = iRow
     ann["image_id"] = im["id"]
     ann["category_id"] = categoryID
-    ann["agcontext_id"] = 0
     ann["agcontext_name"] = "deepweeds"
 
     annotations.append(ann)
@@ -221,7 +220,7 @@ Datasets can be concatenated to include images from multiple different agcontext
 """
 agcontext = [
     {
-        "agcontext_id": 0,
+        "id": 0,
         "agcontext_name": "deepweeds",
         "crop_type": "weed only",
         "bbch_descriptive_text": "na",

--- a/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
+++ b/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
@@ -167,6 +167,8 @@ print(
         len(duplicateImageIDs),
     )
 )
+if missingFiles:
+    print("Example of missing file:", missingFiles[0])
 
 """Create info array and object"""
 

--- a/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
+++ b/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
@@ -203,7 +203,7 @@ collections = [
         "year": 2019,
         "identifier": "doi:10.1038/s41598-018-38343-3",
         "rights": "Apache License 2.0",
-        "accrual_policy": "Closed",
+        "accrual_policy": "closed",
         "id": 0,
     }
 ]

--- a/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
+++ b/conversion_tools/deepweeds_to_json/deepweeds_to_json.py
@@ -222,7 +222,7 @@ agcontext = [
     {
         "id": 0,
         "agcontext_name": "deepweeds",
-        "crop_type": "weed only",
+        "crop_type": "weed_only",
         "bbch_descriptive_text": "na",
         "bbch_code": "na",
         "grains_descriptive_text": "na",

--- a/schema/AgContext.yaml
+++ b/schema/AgContext.yaml
@@ -187,7 +187,7 @@ properties:
 
   location_datum:
     type:
-      int
+      number
     description: |-
         EPSG code of spatial datum.
         A number indicting the EPSG code for the spatial reference system used for the location of the AgContext.

--- a/schema/AgContext.yaml
+++ b/schema/AgContext.yaml
@@ -21,7 +21,7 @@ required:
   - camera_fov
   - photography_description
   - lighting
-  - emr_channels
+#  - emr_channels
   - cropped_to_plant
 
 properties:
@@ -160,6 +160,7 @@ properties:
       - "25-50"
       - "50-75"
       - "75-100"
+      - na
     description: |-
       Percent of coverage in image.
       Approximate measurement of the percent of the soil in the image that is covered by the surface cover.

--- a/schema/AgContext.yaml
+++ b/schema/AgContext.yaml
@@ -112,7 +112,7 @@ properties:
   bbch_code:
     type:
       string
-    pattern: "^gs[0-9][0-9]$|^na$|^(?!.*gs00))"
+    pattern: "^gs[0-9][0-9]$|^na$|^(?!.*gs00)"
     description: |-
         BBCG descriptive text.
         One of several possible strings describing the stage of the crop, chosen from a list of codes used by the BBCH.

--- a/schema/AgContext.yaml
+++ b/schema/AgContext.yaml
@@ -132,6 +132,7 @@ properties:
       - pale_yellow
       - white
       - grey
+      - variable
     description: |-
         Soil colour.
         General description of the soil colour.
@@ -186,10 +187,10 @@ properties:
 
   location_datum:
     type:
-      string
+      int
     description: |-
         EPSG code of spatial datum.
-        A numeric string indicting the EPSG code for the spatial reference system used for the location of the AgContext.
+        A number indicting the EPSG code for the spatial reference system used for the location of the AgContext.
   camera_make:
     type: string
     description: |-

--- a/schema/Annotation.yaml
+++ b/schema/Annotation.yaml
@@ -1,27 +1,24 @@
 $id: https://weedid.sydney.edu.au/schema/Annotation.json
 allOf:
   - type: object
+    required:
+      - id
+      - image_id
+      - category_id
     properties:
-
+      id:
+        type: number
+        description: |-
+          A number to identify the annotation.
+      image_id:
+        type: number
+        description: |-
+          A number identifying the number associated with the annotation.
+      category_id:
+        type: number
+        desciption: |-
+          A number identifying the category which the annotation belongs to.
   - anyOf:
+# TODO: alternative annotation formats
     - type: object
-      properties:
-        id:
-          type: number
-          description: |-
-            A number to identify the annotation.
-        image_id:
-          type: number
-          description: |-
-            A number identifying the number associated with the annotation.
-        category_id:
-          type: number
-          desciption: |-
-            A number identifying the category which the annotation belongs to.
-
     - type: object
-      properties:
-    - type: object
-      properties:
-    - type: object
-      properties:

--- a/schema/main.yaml
+++ b/schema/main.yaml
@@ -10,6 +10,14 @@ required:
   - images
   - annotations
 properties:
+  images:
+    type: array
+    contains:
+      $ref: https://weedid.sydney.edu.au/schema/Image.json
+  annotations:
+    type: array
+    contains:
+      $ref: https://weedid.sydney.edu.au/schema/Annotation.json
   agcontexts:
     type: array
     contains:
@@ -18,11 +26,3 @@ properties:
     type: array
     contains:
       $ref: https://weedid.sydney.edu.au/schema/Collection.json
-  annotations:
-    type: array
-    contains:
-      $ref: https://weedid.sydney.edu.au/schema/Annotation.json
-  images:
-    type: array
-    contains:
-      $ref: https://weedid.sydney.edu.au/schema/Image.json

--- a/schema/main.yaml
+++ b/schema/main.yaml
@@ -1,4 +1,5 @@
 $schema: http://json-schema.org/draft-07/schema#
+$id: https://weedid.sydney.edu.au/schema/main.json
 description: |
   Weed-COCO
   An extension of MS COCO for Weed Identification in grain crops.
@@ -12,17 +13,17 @@ required:
 properties:
   images:
     type: array
-    contains:
+    items:
       $ref: https://weedid.sydney.edu.au/schema/Image.json#/
   annotations:
     type: array
-    contains:
+    items:
       $ref: https://weedid.sydney.edu.au/schema/Annotation.json#/
   agcontexts:
     type: array
-    contains:
+    items:
       $ref: https://weedid.sydney.edu.au/schema/AgContext.json#/
   collections:
     type: array
-    contains:
+    items:
       $ref: https://weedid.sydney.edu.au/schema/Collection.json#/

--- a/schema/main.yaml
+++ b/schema/main.yaml
@@ -13,16 +13,16 @@ properties:
   images:
     type: array
     contains:
-      $ref: https://weedid.sydney.edu.au/schema/Image.json
+      $ref: https://weedid.sydney.edu.au/schema/Image.json#/
   annotations:
     type: array
     contains:
-      $ref: https://weedid.sydney.edu.au/schema/Annotation.json
+      $ref: https://weedid.sydney.edu.au/schema/Annotation.json#/
   agcontexts:
     type: array
     contains:
-      $ref: https://weedid.sydney.edu.au/schema/AgContext.json
+      $ref: https://weedid.sydney.edu.au/schema/AgContext.json#/
   collections:
     type: array
     contains:
-      $ref: https://weedid.sydney.edu.au/schema/Collection.json
+      $ref: https://weedid.sydney.edu.au/schema/Collection.json#/


### PR DESCRIPTION
The orrosenblatt action was limited around multi-file schemas. It seems we were only validating against main.json and no other files.
