### PR TITLE
Update the version of black used in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3.7


### PR DESCRIPTION
Per https://github.com/psf/black/issues/420 adopt a fixed tag. CI can tell us when the code style is out of date with latest black version.