### PR TITLE
Frontend: Hide filter checkboxes unless hovered

### DIFF
--- a/search/src/App.css
+++ b/search/src/App.css
@@ -36,3 +36,12 @@
     transform: rotate(360deg);
   }
 }
+
+/* TODO: use innerClass to get unpacked class name */
+.filter-checkbox + label::before {
+  border-color: white !important;
+}
+
+.filter-checkbox + label:hover::before {
+  border-color: #424242 !important;
+}

--- a/search/src/App.js
+++ b/search/src/App.js
@@ -26,6 +26,10 @@ class App extends Component {
 				multilistFacetProps = {}
 			}
 			let facetProps = {
+				innerClass: {
+					title: "filter-title",
+					checkbox: "filter-checkbox"
+				},
 				queryFormat: "or",
 				URLParams: true,
 				react: {


### PR DESCRIPTION
This is helpful because when no checkboxes are selected, it actually means "all are selected", so the current empty checkboxes are confusing.

![image](https://user-images.githubusercontent.com/78827/95809166-e169f480-0d59-11eb-81be-a8fc289d8dd7.png)
