### PR TITLE
Pin ajv-cli version in workflow

### DIFF
--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
-      - run: npm install -g ajv-cli
+      - run: npm install -g ajv-cli@3.3.0
       - name: Validate JSON with ajv until we are confident with Python's jsonschema
         run: |
           cd weedcoco/schema


### PR DESCRIPTION
CI in https://github.com/Sydney-Informatics-Hub/Weed-ID-Interchange/pull/156 started failing following the release of ajv-cli@4.*