### PR TITLE
Update DB database metadata after upload

### DIFF
--- a/search/django/weedid/tasks.py
+++ b/search/django/weedid/tasks.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+import json
 from celery import shared_task
 from weedcoco.repo.deposit import deposit
 from weedcoco.index.indexing import ElasticSearchIndex
 from weedcoco.index.thumbnailing import thumbnailing
 from weedid.models import Dataset
+from weedid.utils import make_upload_entity_fields
 from core.settings import THUMBNAILS_DIR, REPOSITORY_DIR, DOWNLOAD_DIR
 from pathlib import Path
 
@@ -13,6 +15,14 @@ def submit_upload_task(weedcoco_path, image_dir, upload_id):
     upload_entity = Dataset.objects.get(upload_id=upload_id)
     upload_entity.status = "P"
     upload_entity.status_details = ""
+
+    # Update fields in database
+    # XXX: maybe this should be delayed
+    with open(weedcoco_path) as f:
+        weedcoco = json.load(f)
+    for k, v in make_upload_entity_fields(weedcoco).items():
+        setattr(upload_entity, k, v)
+
     upload_entity.save()
     try:
         new_weedcoco_path = deposit(

--- a/search/django/weedid/utils.py
+++ b/search/django/weedid/utils.py
@@ -37,21 +37,25 @@ def add_agcontexts(weedcoco_path, ag_contexts):
         json.dump(data, jsonFile)
 
 
+def make_upload_entity_fields(weedcoco):
+    return {
+        "agcontext": weedcoco["agcontexts"],
+        "metadata": {
+            "info": weedcoco["info"],
+            "license": weedcoco["license"],
+            "collections": weedcoco["collections"],
+        },
+    }
+
+
 def create_upload_entity(weedcoco_path, upload_id, upload_userid):
     upload_user = WeedidUser.objects.get(id=upload_userid)
+
     with open(weedcoco_path) as f:
         weedcoco_json = json.load(f)
-    upload_entity = Dataset(
-        upload_id=upload_id,
-        agcontext=weedcoco_json["agcontexts"],
-        user=upload_user,
-        status="N",
-        metadata={
-            "info": weedcoco_json["info"],
-            "license": weedcoco_json["license"],
-            "collections": weedcoco_json["collections"],
-        },
-    )
+    fields = make_upload_entity_fields(weedcoco_json)
+
+    upload_entity = Dataset(upload_id=upload_id, user=upload_user, status="N", **fields)
     upload_entity.save()
     upload_user.latest_upload = upload_entity
     upload_user.save()


### PR DESCRIPTION
Am I correct in thinking, @ElevnLi, that currently the upload DB record is not updated after the agcontext and metadata are uploaded? Here's a change that updates the DB record in `submit_upload_task`.