### PR TITLE
Attempt to fix issue where CSRF is not set before POST is performed

### DIFF
--- a/search/django/weedid/urls.py
+++ b/search/django/weedid/urls.py
@@ -24,10 +24,10 @@ api_urlpatterns = [
     path("logout/", views.user_logout, name="user_logout"),
     path("login_status/", views.user_login_status, name="user_login_status"),
     path("login_google/", views.login_google, name="login_google"),
+    path("set_csrf/", views.set_csrf),
 ]
 
 urlpatterns = [
     path("api/", include(api_urlpatterns)),
     re_path(r"^elasticsearch", views.elasticsearch_query, name="elasticsearch_query"),
-    path("set_csrf/", views.set_csrf),
 ]

--- a/search/django/weedid/urls.py
+++ b/search/django/weedid/urls.py
@@ -29,4 +29,5 @@ api_urlpatterns = [
 urlpatterns = [
     path("api/", include(api_urlpatterns)),
     re_path(r"^elasticsearch", views.elasticsearch_query, name="elasticsearch_query"),
+    path("set_csrf/", views.set_csrf),
 ]

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -19,6 +19,12 @@ from weedcoco.validation import validate, ValidationError
 from django.contrib.auth import login, logout
 from django.contrib.auth.hashers import check_password
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+
+@ensure_csrf_cookie
+def set_csrf(request):
+    return HttpResponse("Success")
 
 
 def elasticsearch_query(request):

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -19,7 +19,7 @@ from weedcoco.validation import validate, ValidationError
 from django.contrib.auth import login, logout
 from django.contrib.auth.hashers import check_password
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 
 @ensure_csrf_cookie
@@ -27,13 +27,8 @@ def set_csrf(request):
     return HttpResponse("Success")
 
 
-@csrf_exempt
 def elasticsearch_query(request):
     elasticsearch_url = "/".join(request.path.split("/")[3:])
-    if not elasticsearch_url.startswith("_msearch"):
-        return HttpResponseForbidden("Only _msearch queries are currently forwarded")
-    if request.method not in ["POST", "GET"]:
-        return HttpResponseNotAllowed(request.method)
     elasticsearch_response = requests.post(
         url=f"http://elasticsearch:9200/{elasticsearch_url}",
         data=request.body,

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -19,7 +19,7 @@ from weedcoco.validation import validate, ValidationError
 from django.contrib.auth import login, logout
 from django.contrib.auth.hashers import check_password
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
-from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
 
 
 @ensure_csrf_cookie
@@ -27,8 +27,13 @@ def set_csrf(request):
     return HttpResponse("Success")
 
 
+@csrf_exempt
 def elasticsearch_query(request):
     elasticsearch_url = "/".join(request.path.split("/")[3:])
+    if not elasticsearch_url.startswith("_msearch"):
+        return HttpResponseForbidden("Only _msearch queries are currently forwarded")
+    if request.method not in ["POST", "GET"]:
+        return HttpResponseNotAllowed(request.method)
     elasticsearch_response = requests.post(
         url=f"http://elasticsearch:9200/{elasticsearch_url}",
         data=request.body,

--- a/search/src/Components/auth/auth_prompt.js
+++ b/search/src/Components/auth/auth_prompt.js
@@ -11,7 +11,6 @@ import Cookies from 'js-cookie';
 
 export default function AuthPrompt(props) {
   const baseURL = new URL(window.location.origin);
-  const csrftoken = Cookies.get('csrftoken');
   const [open, setOpen] = React.useState(false);
   const [prompt, setPrompt] = React.useState('login');
 
@@ -40,7 +39,7 @@ export default function AuthPrompt(props) {
         url: baseURL + 'api/login_google/',
         mode: 'same-origin',
         data: {'email': response.profileObj.email, 'googleId': response.profileObj.googleId},
-        headers: {'X-CSRFToken': csrftoken }
+        headers: {'X-CSRFToken': Cookies.get('csrftoken') }
     })
     .then(() => props.handleLogin())
     .catch(error => {console.log(error)})

--- a/search/src/Components/auth/login.js
+++ b/search/src/Components/auth/login.js
@@ -9,8 +9,6 @@ import axios from 'axios';
 import Cookies from 'js-cookie';
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 const useStyles = (theme) => ({
     paper: {
         display: 'flex',
@@ -50,7 +48,7 @@ class LoginComponent extends React.Component {
             url: baseURL + 'api/login/',
             mode: 'same-origin',
             data: bodyFormData,
-            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': csrftoken }
+            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': Cookies.get('csrftoken') }
         })
         .then((response) => {
             console.log(response);

--- a/search/src/Components/auth/register.js
+++ b/search/src/Components/auth/register.js
@@ -10,8 +10,6 @@ import axios from 'axios';
 import Cookies from 'js-cookie'
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 const useStyles = (theme) => ({
     paper: {
       display: 'flex',
@@ -51,7 +49,7 @@ class RegisterComponent extends React.Component {
             url: baseURL + 'api/register/',
             mode: 'same-origin',
             data: bodyFormData,
-            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': csrftoken }
+            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': Cookies.get('csrftoken') }
         })
         .then((response) => {
             console.log(response);

--- a/search/src/Components/dataset/dataset_summary.js
+++ b/search/src/Components/dataset/dataset_summary.js
@@ -19,8 +19,6 @@ import IconButton from '@material-ui/core/IconButton';
 import Cookies from 'js-cookie'
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 const useStyles = (theme) => ({
   root: {
     flexGrow: 1,
@@ -194,7 +192,7 @@ class DatasetSummaryPage extends Component {
         url: baseURL + "api/upload_info/",
         mode: 'same-origin',
         data: body,
-        headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': csrftoken }
+        headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': Cookies.get('csrftoken') }
     })
     .then(res => res.data)
     .then(json => {

--- a/search/src/Components/upload/react-images-upload/index.js
+++ b/search/src/Components/upload/react-images-upload/index.js
@@ -6,8 +6,6 @@ import axios from 'axios';
 import Cookies from 'js-cookie'
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 const styles = {
   display: "flex",
   alignItems: "center",
@@ -125,7 +123,7 @@ class ReactImageUploadComponent extends React.Component {
             method: 'post',
             url: this.props.uploadURL,
             data: body,
-            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': csrftoken }
+            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': Cookies.get('csrftoken') }
         }).then(res => {
             if(res.status === 200){
                 dataURLs.push(newFileData.dataURL);

--- a/search/src/Components/upload/upload_stepper.js
+++ b/search/src/Components/upload/upload_stepper.js
@@ -13,7 +13,6 @@ import MetadataForm from '../forms/MetadataForm';
 import axios from 'axios';
 import Cookies from 'js-cookie';
 
-const csrftoken = Cookies.get('csrftoken');
 const baseURL = new URL(window.location.origin);
 
 const useStyles = (theme) => ({
@@ -204,7 +203,7 @@ class UploadStepper extends React.Component {
                 "upload_id": this.state.upload_id,
                 "ag_contexts": this.state.ag_context
             },
-            headers: {'X-CSRFToken': csrftoken }
+            headers: {'X-CSRFToken': Cookies.get('csrftoken') }
         }).then(res => {
             console.log(res)
             this.handleErrorMessage("")
@@ -224,7 +223,7 @@ class UploadStepper extends React.Component {
                 "upload_id": this.state.upload_id,
                 "metadata": this.state.metadata
             },
-            headers: {'X-CSRFToken': csrftoken }
+            headers: {'X-CSRFToken': Cookies.get('csrftoken') }
         }).then(res => {
             console.log(res)
             this.handleErrorMessage("")
@@ -244,7 +243,7 @@ class UploadStepper extends React.Component {
             method: 'post',
             url: baseURL + "api/submit_deposit/",
             data: body,
-            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': csrftoken }
+            headers: {'Content-Type': 'multipart/form-data', 'X-CSRFToken': Cookies.get('csrftoken') }
         })
     }
 

--- a/search/src/Components/upload/uploader_single.js
+++ b/search/src/Components/upload/uploader_single.js
@@ -4,8 +4,6 @@ import Dropzone from 'react-dropzone-uploader';
 import Cookies from 'js-cookie'
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 function readBody(xhr) {
     var data;
     if (!xhr.responseType || xhr.responseType === "text") {
@@ -25,7 +23,7 @@ const UploaderSingle  = (props) => {
         body.append('weedcoco', file)
         return { url: baseURL + 'api/upload/',
                  mode: 'same-origin',
-                 headers: {'X-CSRFToken': csrftoken},
+                 headers: {'X-CSRFToken': Cookies.get('csrftoken')},
                  body
                }
     }

--- a/search/src/Components/wrapper/navbar.js
+++ b/search/src/Components/wrapper/navbar.js
@@ -17,6 +17,8 @@ import UploadComponent from './upload';
 import DatasetComponent from './datasets';
 import WeedCOCOComponent from './weedcoco';
 import AboutComponent from './about';
+import axios from 'axios';
+import Cookies from 'js-cookie';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -124,6 +126,14 @@ const DesktopNavbar = (props) => {
   );
 }
 
+const manageCsrf = () => {
+  const csrftoken = Cookies.get('csrftoken');
+  if (!csrftoken) {
+    axios.get('/set_csrf');
+  }
+}
+
+
 export default function NavbarComponent(props) {
 
   const classes = useStyles();
@@ -133,6 +143,8 @@ export default function NavbarComponent(props) {
 
   const [selectedTab, setSelectedTab] = React.useState(page);
   const [mobileView, setMobileView] = React.useState(false);
+
+  manageCsrf();  // should be included in componentWillMount rather
 
   useEffect(() => {
     const setResponsiveness = () => {

--- a/search/src/Components/wrapper/navbar.js
+++ b/search/src/Components/wrapper/navbar.js
@@ -141,6 +141,7 @@ const DesktopNavbar = (props) => {
 const manageCsrf = () => {
   const csrftoken = Cookies.get('csrftoken');
   if (!csrftoken) {
+    // Reloading the page to set up csrf token is a hack
     axios.get('/api/set_csrf/').then(() => window.location.reload());
   }
 }
@@ -156,7 +157,7 @@ export default function NavbarComponent(props) {
   const [mobileView, setMobileView] = React.useState(false);
 
   useEffect(() => {
-    manageCsrf();  // should be included in componentWillMount rather
+    manageCsrf();
     const setResponsiveness = () => {
       return window.innerWidth < 1000
         ? setMobileView(true)

--- a/search/src/Components/wrapper/navbar.js
+++ b/search/src/Components/wrapper/navbar.js
@@ -129,10 +129,9 @@ const DesktopNavbar = (props) => {
 const manageCsrf = () => {
   const csrftoken = Cookies.get('csrftoken');
   if (!csrftoken) {
-    axios.get('/set_csrf');
+    axios.get('/api/set_csrf');
   }
 }
-
 
 export default function NavbarComponent(props) {
 
@@ -144,9 +143,8 @@ export default function NavbarComponent(props) {
   const [selectedTab, setSelectedTab] = React.useState(page);
   const [mobileView, setMobileView] = React.useState(false);
 
-  manageCsrf();  // should be included in componentWillMount rather
-
   useEffect(() => {
+    manageCsrf();  // should be included in componentWillMount rather
     const setResponsiveness = () => {
       return window.innerWidth < 1000
         ? setMobileView(true)

--- a/search/src/Components/wrapper/reactive_search.js
+++ b/search/src/Components/wrapper/reactive_search.js
@@ -11,8 +11,6 @@ import Cookies from 'js-cookie';
 import axios from 'axios';
 
 
-const csrftoken = Cookies.get('csrftoken');
-
 const theme = {
     typography: {
         fontFamily: 'Raleway, Helvetica, sans-serif',
@@ -64,7 +62,7 @@ export const TestWeedAIResultCard = () => {
         app="weedid"
         url={"https://localhost/elasticsearch/"}
         theme={theme}
-        headers={{'X-CSRFToken': csrftoken}}
+        headers={{'X-CSRFToken': Cookies.get('csrftoken')}}
     >
       <WeedAIResultCard item={ {
         "id": 20,
@@ -558,7 +556,7 @@ class ReactiveSearchComponent extends Component {
                 app="weedid"
                 url={baseURL + "elasticsearch/"}
                 theme={theme}
-                headers={{'X-CSRFToken': csrftoken}}
+                headers={{'X-CSRFToken': Cookies.get('csrftoken')}}
             >
                 <div style={{ position: "fixed", width: "20rem", overflow: "scroll", height: "90%", left: 0, padding: '0 1rem' }}>
                     <MultiList


### PR DESCRIPTION
The problem with this solution is that other queries (notably automatic `POST elasticsearch/_msearch`) might fail while this is responding. We might need to make `elasticsearch` queries CSRF-exempt, and need to make sure that other queries that are executed automatically are not POST (see #245).