### PR TITLE
quick fix to reflect coco and weedcoco error

### DIFF
--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -15,7 +15,7 @@ from weedid.utils import (
     add_metadata,
 )
 from weedid.models import Dataset, WeedidUser
-from weedcoco.validation import validate, ValidationError
+from weedcoco.validation import validate
 from django.contrib.auth import login, logout
 from django.contrib.auth.hashers import check_password
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
@@ -53,10 +53,9 @@ def upload(request):
         upload_dir, upload_id = setup_upload_dir(os.path.join(UPLOAD_DIR, str(user.id)))
         weedcoco_path = store_tmp_weedcoco(file_weedcoco, upload_dir)
         create_upload_entity(weedcoco_path, upload_id, user.id)
-    except ValidationError as e:
+    # Do we still need to separate ValidationError?
+    except Exception as e:
         return HttpResponseForbidden(str(e))
-    except Exception:
-        return HttpResponseForbidden("There is something wrong with the file")
     else:
         return HttpResponse(json.dumps({"upload_id": upload_id, "images": images}))
 

--- a/search/src/Components/upload/uploader_single.js
+++ b/search/src/Components/upload/uploader_single.js
@@ -4,18 +4,6 @@ import Dropzone from 'react-dropzone-uploader';
 import Cookies from 'js-cookie'
 
 
-function readBody(xhr) {
-    var data;
-    if (!xhr.responseType || xhr.responseType === "text") {
-        data = xhr.responseText;
-    } else if (xhr.responseType === "document") {
-        data = xhr.responseXML;
-    } else {
-        data = xhr.response;
-    }
-    return data;
-}
-
 const UploaderSingle  = (props) => {
     const baseURL = new URL(window.location.origin);
     const getUploadParams = ({ file, meta }) => {
@@ -36,8 +24,7 @@ const UploaderSingle  = (props) => {
             props.handleErrorMessage("")
         }
         else if (status === 'error_upload'){
-            // Weird things happen here
-            props.handleErrorMessage("There is something wrong with the file")
+            xhr.addEventListener('loadend', (e) => {props.handleErrorMessage(e.target.responseText)});
         }
         else if (status === 'error_file_size') {
             props.handleErrorMessage("The file size exceeds the limitation")
@@ -46,11 +33,6 @@ const UploaderSingle  = (props) => {
             props.handleErrorMessage("")
         }
     }
-  
-    // const handleSubmit = (files, allFiles) => {
-    //   files.map(f => f.restart())
-    //   allFiles.forEach(f => f.remove())
-    // }
   
     return (
       <Dropzone


### PR DESCRIPTION
It should be the quickest way to show upload error. We can summarise the traceback in the future if needed. Maybe other alternative method of traceback or change the limit? Showing the whole stack to user is a bit overwhelming I guess.