### PR TITLE
Allow dataset Creators to have affiliation

### DIFF
--- a/search/src/Components/dataset/dataset_summary.js
+++ b/search/src/Components/dataset/dataset_summary.js
@@ -116,6 +116,11 @@ const AgContextDetails = (props) => {
 
 export const DatasetSummary = (props) => {
     const {metadata, agcontexts, classes, rootURL, upload_id} = props;
+    const linkedEntity = (ent) => {
+      if (ent.sameAs)
+        return (<a href={ent.sameAs}>{ent.name}</a>);
+      return ent.name;
+    }
     return (
       <React.Fragment>
         <script type="application/ld+json">
@@ -146,11 +151,25 @@ export const DatasetSummary = (props) => {
                 <dt>Creators:</dt>
                 <dd>
                   <ul>
-                  {metadata.creator.map((creator, i) => (<li key={i}>{creator.sameAs ? (<a href={creator.sameAs}>{creator.name}</a>) : creator.name}</li>))}
+                  {metadata.creator.map((creator, i) => (
+                    <li key={i}>
+                      {linkedEntity(creator)}{creator.affiliation ? (<span>, {linkedEntity(creator.affiliation)}</span>) : []}
+                    </li>
+                  ))}
                   </ul>
                 </dd>
                 <dt>Licence:</dt>
                 <dd>{<a href={metadata.license}>{metadata.license}</a>}</dd>
+                {metadata.funder ?
+                    <React.Fragment>
+                    <dt>Funders:</dt>
+                    <dd>
+                      <ul>
+                        {metadata.funder.map(ent => <li key={ent.name}>{linkedEntity(ent)}</li>)}
+                      </ul>
+                    </dd>
+                    </React.Fragment>
+                : []}
               </dl>
               { /* TODO: link to Explore searching for just this dataset */ }
             </div>
@@ -219,8 +238,9 @@ export const TestDatasetSummary = () => {
         "metadata": {
             "creator": [
                 {"name": "Sebastian Haug"},
-                {"name": "J\u00f6rn Ostermann", "sameAs": "https://orcid.org/0000-0002-6743-3324"}
+                {"name": "J\u00f6rn Ostermann", "sameAs": "https://orcid.org/0000-0002-6743-3324", "affiliation": {"name": "Leibniz Universität Hannover", "sameAs": "https://ror.org/0304hq317", "@type": "Organization"}}
             ],
+            "funder": [{"name": "some funder"}],
             "name": "A Crop/Weed Field Image Dataset for the Evaluation of Computer Vision Based Precision Agriculture Tasks",
             "datePublished": "2015-03-19",
             "identifier": ["doi:10.1007/978-3-319-16220-1_8"],

--- a/search/src/Components/forms/MetadataForm.js
+++ b/search/src/Components/forms/MetadataForm.js
@@ -24,12 +24,12 @@ const uischema = {
                 },
                 {
                     "type": "Control",
-                    "scope": "#/properties/creator"
+                    "scope": "#/properties/description",
+                    "options": {"multi": true}
                 },
                 {
                     "type": "Control",
-                    "scope": "#/properties/description",
-                    "options": {"multi": true}
+                    "scope": "#/properties/license"
                 },
                 {
                     "type": "Control",
@@ -37,7 +37,8 @@ const uischema = {
                 },
                 {
                     "type": "Control",
-                    "scope": "#/properties/license"
+                    "scope": "#/properties/creator",
+                    "label": "Authors/Creators",
                 },
             ]
         },

--- a/search/src/Schemas/Metadata.json
+++ b/search/src/Schemas/Metadata.json
@@ -30,6 +30,17 @@
           "format": "uri",
           "title": "ORCID ID (optional)",
           "description": "ORCID ID (see https://orcid.org)"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "address": {
+          "type": "string",
+          "description": "Physical address"
+        },
+        "affiliation": {
+          "$ref": "#/definitions/Organization"
         }
       },
       "title": "Person"
@@ -48,6 +59,10 @@
           "format": "uri",
           "title": "Research Organization Registry (ROR) ID",
           "description": "ROR ID (see https://ror.org)"
+        },
+        "address": {
+          "type": "string",
+          "description": "Physical address"
         }
       },
       "title": "Organization"

--- a/search/src/Schemas/Metadata.json
+++ b/search/src/Schemas/Metadata.json
@@ -33,11 +33,13 @@
         },
         "email": {
           "type": "string",
-          "format": "email"
+          "format": "email",
+          "title": "Email Address (optional)"
         },
         "address": {
           "type": "string",
-          "description": "Physical address"
+          "description": "Physical address",
+          "title": "Address (optional)"
         },
         "affiliation": {
           "$ref": "#/definitions/Organization"

--- a/search/src/Schemas/Metadata.json
+++ b/search/src/Schemas/Metadata.json
@@ -36,11 +36,6 @@
           "format": "email",
           "title": "Email Address (optional)"
         },
-        "address": {
-          "type": "string",
-          "description": "Physical address",
-          "title": "Address (optional)"
-        },
         "affiliation": {
           "$ref": "#/definitions/Organization"
         }

--- a/weedcoco/schema/Metadata.yaml
+++ b/weedcoco/schema/Metadata.yaml
@@ -29,10 +29,6 @@ definitions:
         type: string
         format: email
         title: Email Address (optional)
-      address:
-        type: string
-        description: Physical address
-        title: Address (optional)
       affiliation:
         $ref: "#/definitions/Organization"
     title: Person

--- a/weedcoco/schema/Metadata.yaml
+++ b/weedcoco/schema/Metadata.yaml
@@ -28,9 +28,11 @@ definitions:
       email:
         type: string
         format: email
+        title: Email Address (optional)
       address:
         type: string
         description: Physical address
+        title: Address (optional)
       affiliation:
         $ref: "#/definitions/Organization"
     title: Person

--- a/weedcoco/schema/Metadata.yaml
+++ b/weedcoco/schema/Metadata.yaml
@@ -25,6 +25,14 @@ definitions:
         format: uri
         title: ORCID ID (optional)
         description: ORCID ID (see https://orcid.org)
+      email:
+        type: string
+        format: email
+      address:
+        type: string
+        description: Physical address
+      affiliation:
+        $ref: "#/definitions/Organization"
     title: Person
   Organization:
     type: object
@@ -38,6 +46,9 @@ definitions:
         format: uri
         title: Research Organization Registry (ROR) ID
         description: ROR ID (see https://ror.org)
+      address:
+        type: string
+        description: Physical address
     title: Organization
 properties:
   name:


### PR DESCRIPTION
This adds a few missing fields to the metadata form...

Initially:
![image](https://user-images.githubusercontent.com/78827/108838868-57e00280-7628-11eb-9b87-cdf6abbd7103.png)

Adding an author:
![image](https://user-images.githubusercontent.com/78827/108838885-60d0d400-7628-11eb-8b70-c778aa414aa0.png)
